### PR TITLE
include cmath to make std::pow() available

### DIFF
--- a/src/frovedis/matrix/rowmajor_matrix.hpp
+++ b/src/frovedis/matrix/rowmajor_matrix.hpp
@@ -3,6 +3,7 @@
 
 #include <fstream>
 #include <dirent.h>
+#include <cmath>
 #include <sys/stat.h>
 #include <sys/types.h>
 


### PR DESCRIPTION
Very small change to `rowmajor_matrix.hpp` which fixes an error like following in my environment.

```
rowmajor_matrix.hpp: In member function ‘frovedis::rowmajor_matrix_local<T> frovedis::rowmajor_matrix_local<T>::pow_val(T) const’:
rowmajor_matrix.hpp:473:20: error: ‘pow’ is not a member of ‘std’
     valp[i] = std::pow(valp[i], exponent);
                    ^~~
```
