### PR TITLE
Fix an overrun error in groupby_sum()

### DIFF
--- a/src/frovedis/matrix/spmspv.hpp
+++ b/src/frovedis/matrix/spmspv.hpp
@@ -89,10 +89,9 @@ void groupby_sum(const std::vector<K>& key, const std::vector<V>& val,
         }
       }
     }
-    size_t rest_idx = 0;
+    size_t rest_idx = each * SPMSPV_VLEN;
     if(rest != 0) {
-      size_t rest_idx_start = each * SPMSPV_VLEN;
-      rest_idx = rest_idx_start;
+      size_t rest_idx_start = rest_idx;
       auto current_key_rest = keyp[rest_idx_start];
       auto current_val_rest = valp[rest_idx_start];
       // no vector loop


### PR DESCRIPTION
This patch fixes an overrun problem, which occurs when `size` is a multiple of `SPMSPV_VLEN`.
In such case,  `rest_size` can be negative which ends up causing a buffer overrun error.